### PR TITLE
Bump commons-email from 1.3.3 to 1.5 in /dhis-2

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -821,7 +821,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-email</artifactId>
-        <version>1.3.3</version>
+        <version>1.5</version>
       </dependency>
       <dependency>
         <groupId>net.sourceforge.javacsv</groupId>


### PR DESCRIPTION
Bumps commons-email from 1.3.3 to 1.5.

---
updated-dependencies:
- dependency-name: org.apache.commons:commons-email dependency-type: direct:production ...

Signed-off-by: dependabot[bot] <support@github.com>