### PR TITLE
Bump poi from 3.17 to 4.1.1 in /dhis-2

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -687,7 +687,7 @@
       <dependency>
         <groupId>org.apache.poi</groupId>
         <artifactId>poi</artifactId>
-        <version>3.17</version>
+        <version>4.1.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.poi</groupId>


### PR DESCRIPTION
Bumps poi from 3.17 to 4.1.1.

---
updated-dependencies:
- dependency-name: org.apache.poi:poi dependency-type: direct:production ...

Signed-off-by: dependabot[bot] <support@github.com>