### PR TITLE
Bump commons-io from 2.6 to 2.7 in /dhis-2

### DIFF
--- a/dhis-2/pom.xml
+++ b/dhis-2/pom.xml
@@ -800,7 +800,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.6</version>
+        <version>2.7</version>
       </dependency>
       <dependency>
         <groupId>commons-logging</groupId>


### PR DESCRIPTION
Bumps commons-io from 2.6 to 2.7.

Signed-off-by: dependabot[bot] <support@github.com>